### PR TITLE
tsconfig: Enable `strict` option

### DIFF
--- a/packages/tsconfig/tsconfig.json
+++ b/packages/tsconfig/tsconfig.json
@@ -1,1 +1,5 @@
-{}
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}


### PR DESCRIPTION
## 📘 Document

<https://www.typescriptlang.org/tsconfig#strict>

## 👺 Behavior

Additional errors may occur due to typescript version upgrade

### Related Options [2022-04-27]

1. [strictNullChecks](https://www.typescriptlang.org/tsconfig#strictNullChecks)
2. [strictBindCallApply](https://www.typescriptlang.org/tsconfig#strictBindCallApply)
3. [strictFunctionTypes](https://www.typescriptlang.org/tsconfig#strictFunctionTypes)
4. [strictPropertyInitializ](https://www.typescriptlang.org/tsconfig#strictPropertyInitialization)

## 💡 Proposal

Turn on the `strict` option in common
